### PR TITLE
Feature/es name template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,18 @@ before_install:
   - docker-compose -f docker-compose.test.yml up -d
   - sleep 10
 
+env:
+  - ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='{db}.{collection}'
+  # This is a fake value that is ignored by the doc manager. I don't know how to
+  # run a matrix build with env variable 'unset'
+  - ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='None'
+
 jobs:
   fast_finish: true
   include:
+  # test with custom es index name template
+  - python: &latest_py3 3.6
+    env: MONGODB=3.2.11 TOXENV=elastic7
   - python: &latest_py3 3.6
     env: MONGODB=3.2.11 TOXENV=elastic7
   - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,12 @@ before_install:
   - docker-compose -f docker-compose.test.yml up -d
   - sleep 10
 
-env:
-  - ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='{db}.{collection}'
-  # This is a fake value that is ignored by the doc manager. I don't know how to
-  # run a matrix build with env variable 'unset'
-  - ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='None'
-
 jobs:
   fast_finish: true
   include:
   # test with custom es index name template
+  - python: &latest_py3 3.6
+    env: MONGODB=3.2.11 TOXENV=elastic7 ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='{db}.{collection}'
   - python: &latest_py3 3.6
     env: MONGODB=3.2.11 TOXENV=elastic7
   - python: &latest_py3 3.6

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,14 @@ Changelog
 ~~~~~~~~~
 The following are the changes/differences between ``elastic7-doc-manager`` and ``elastic2-doc-manager``.
 
-1. MongoDB database + MongoDB collection is mapped to a single Elasticsearch index with the convention: ``{db}_{collection}`` where ``db`` and ``collection`` are the lowercase names of the MongoDB database and MongoDB collection.
+1. MongoDB database + MongoDB collection is mapped to a single Elasticsearch index with the convention: ``{db}_{collection}`` where ``db`` and ``collection`` are the lowercase names of the MongoDB database and MongoDB collection. To change
+the format, specify it using an environment variable ``ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE``.
+
+```
+ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE='{db}.{collection}'
+```
+If the format is invalid, it will be ignored
+
 2. No more ``doc_type`` for ES indices.
 3. Removed ``mapper-attachment`` plugin which was responsible for parsing file attachments, and replaced it with newer ``ingest-attachment`` plugin.
 

--- a/tests/test_elastic7.py
+++ b/tests/test_elastic7.py
@@ -45,7 +45,8 @@ class ElasticsearchTestCase(unittest.TestCase):
         But when os variable ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE is set,
         we will use that template
         """
-        return self.elastic_doc._index_and_mapping('.'.join(default_index.split('_')))
+        index, _ = self.elastic_doc._index_and_mapping('.'.join(default_index.split('_')))
+        return index
 
     def setUp(self):
         # Create target index in elasticsearch

--- a/tests/test_elastic7.py
+++ b/tests/test_elastic7.py
@@ -38,30 +38,39 @@ class ElasticsearchTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.elastic_conn = Elasticsearch(hosts=[elastic_pair])
 
+    def wrap_index(self, default_index):
+        """The tests will use default index separator `_` when ENV variable is not set for
+        index separator.
+
+        But when os variable ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE is set,
+        we will use that template
+        """
+        return self.elastic_doc._index_and_mapping('.'.join(default_index.split('_')))
+
     def setUp(self):
         # Create target index in elasticsearch
-        self.elastic_conn.indices.create(index="test_test", ignore=400)
-        self.elastic_conn.indices.create(index="test_test2", ignore=400)
-        self.elastic_conn.cluster.health(wait_for_status="yellow", index="test_test")
         self.elastic_doc = DocManager(elastic_pair, auto_commit_interval=0)
+        self.elastic_conn.indices.create(index=self.wrap_index("test_test"), ignore=400)
+        self.elastic_conn.indices.create(index=self.wrap_index("test_test2"), ignore=400)
+        self.elastic_conn.cluster.health(wait_for_status="yellow", index=self.wrap_index("test_test"))
 
     def tearDown(self):
-        self.elastic_conn.indices.delete(index="test_test", ignore=404)
-        self.elastic_conn.indices.delete(index="test_test2", ignore=404)
+        self.elastic_conn.indices.delete(index=self.wrap_index("test_test"), ignore=404)
+        self.elastic_conn.indices.delete(index=self.wrap_index("test_test2"), ignore=404)
         self.elastic_doc.stop()
 
     def _search(self, query=None):
         query = query or {"match_all": {}}
         return self.elastic_doc._stream_search(
-            index="test_test", body={"query": query}
+            index=self.wrap_index("test_test"), body={"query": query}
         )
 
     def _count(self):
-        return self.elastic_conn.count(index="test_test")["count"]
+        return self.elastic_conn.count(index=self.wrap_index("test_test"))["count"]
 
     def _remove(self):
         bulk_deletes = []
-        for result in scan(self.elastic_conn, index="test_test"):
+        for result in scan(self.elastic_conn, index=self.wrap_index("test_test")):
             result["_op_type"] = "delete"
             bulk_deletes.append(result)
         bulk(self.elastic_conn, bulk_deletes)

--- a/tests/test_elastic7_doc_manager.py
+++ b/tests/test_elastic7_doc_manager.py
@@ -45,12 +45,12 @@ def disable_auto_refresh(func):
     def _disable_auto_refresh(self, *args, **kwargs):
         try:
             self.elastic_conn.indices.put_settings(
-                index="test_test", body={"index": {"refresh_interval": "-1"}}
+                index=self.wrap_index("test_test"), body={"index": {"refresh_interval": "-1"}}
             )
             return func(self, *args, **kwargs)
         finally:
             self.elastic_conn.indices.put_settings(
-                index="test_test", body={"index": {"refresh_interval": "1s"}}
+                index=self.wrap_index("test_test"), body={"index": {"refresh_interval": "1s"}}
             )
 
     return _disable_auto_refresh
@@ -98,7 +98,7 @@ class TestElasticDocManager(ElasticsearchTestCase):
         docc = {"_id": "1", "name": "John"}
         self.elastic_doc.upsert(docc, *TESTARGS)
         res = self.elastic_conn.search(
-            index="test_test", body={"query": {"match_all": {}}}
+            index=self.wrap_index("test_test"), body={"query": {"match_all": {}}}
         )["hits"]["hits"]
         for doc in res:
             self.assertEqual(doc["_id"], "1")
@@ -157,7 +157,7 @@ class TestElasticDocManager(ElasticsearchTestCase):
         self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
 
         res = self.elastic_conn.search(
-            index="test_test", body={"query": {"match_all": {}}}
+            index=self.wrap_index("test_test"), body={"query": {"match_all": {}}}
         )["hits"]["hits"]
 
         for doc in res:
@@ -193,14 +193,14 @@ class TestElasticDocManager(ElasticsearchTestCase):
         docc = {"_id": "1", "name": "John"}
         self.elastic_doc.upsert(docc, *TESTARGS)
         res = self.elastic_conn.search(
-            index="test_test", body={"query": {"match_all": {}}}
+            index=self.wrap_index("test_test"), body={"query": {"match_all": {}}}
         )["hits"]["hits"]
         res = [x["_source"] for x in res]
         self.assertEqual(len(res), 1)
 
         self.elastic_doc.remove(docc["_id"], *TESTARGS)
         res = self.elastic_conn.search(
-            index="test_test", body={"query": {"match_all": {}}}
+            index=self.wrap_index("test_test"), body={"query": {"match_all": {}}}
         )["hits"]["hits"]
         res = [x["_source"] for x in res]
         self.assertEqual(len(res), 0)
@@ -356,7 +356,7 @@ class TestElasticDocManager(ElasticsearchTestCase):
         docc = {"_id": "6", "name": "Mr T."}
         self.elastic_doc.upsert(docc, "test.test", ts + 1)
 
-        self.assertEqual(self.elastic_doc.elastic.count(index="test_test")["count"], 3)
+        self.assertEqual(self.elastic_doc.elastic.count(index=self.wrap_index("test_test"))["count"], 3)
         doc = self.elastic_doc.get_last_doc()
         self.assertEqual(doc["_id"], "4")
 
@@ -364,7 +364,7 @@ class TestElasticDocManager(ElasticsearchTestCase):
         self.elastic_doc.upsert(docc, "test.test", ts + 4)
         doc = self.elastic_doc.get_last_doc()
         self.assertEqual(doc["_id"], "6")
-        self.assertEqual(self.elastic_doc.elastic.count(index="test_test")["count"], 3)
+        self.assertEqual(self.elastic_doc.elastic.count(index=self.wrap_index("test_test"))["count"], 3)
 
     def test_commands(self):
         cmd_args = ("test.$cmd", 1)
@@ -387,7 +387,7 @@ class TestElasticDocManager(ElasticsearchTestCase):
 
         res = list(
             self.elastic_doc._stream_search(
-                index="test_test2", body={"query": {"match_all": {}}}
+                index=self.wrap_index("test_test2"), body={"query": {"match_all": {}}}
             )
         )
         for d in docs:
@@ -395,13 +395,13 @@ class TestElasticDocManager(ElasticsearchTestCase):
 
         self.elastic_doc.handle_command({"drop": "test2"}, *cmd_args)
         retry_until_ok(self.elastic_conn.indices.refresh, index="")
-        assert not self.elastic_conn.indices.exists("test_test2")
+        assert not self.elastic_conn.indices.exists(self.wrap_index("test_test2"))
 
         self.elastic_doc.handle_command({"create": "test2"}, *cmd_args)
         retry_until_ok(self.elastic_conn.indices.refresh, index="")
         self.elastic_doc.handle_command({"dropDatabase": 1}, *cmd_args)
         retry_until_ok(self.elastic_conn.indices.refresh, index="")
-        self.assertNotIn("test_test2", self._indices())
+        self.assertNotIn(self.wrap_index("test_test2"), self._indices())
 
     def buffer_and_drop(self):
         """Insert document and drop collection while doc is in buffer"""


### PR DESCRIPTION
Allow specifying custom ES name indexing template (apart from namespace config).

`ELASTIC7_DOC_MANAGER_ES_INDEX_NAME_TEMPLATE`